### PR TITLE
Feature/14

### DIFF
--- a/docs/google.rst
+++ b/docs/google.rst
@@ -1,10 +1,11 @@
 Google
 ------
 
-Google Searchconsole API 호출을 위한 모듈로 현재는 Search Analytics query만 제공한다.
+Google 에서 제공하는 데이터를 수집하기 위한 모듈이다.
+현재는 Google Searchconsole API의 Search Analytics query와 GoogleAds의 search_stream 을 제공한다.
 
 https://developers.google.com/webmaster-tools/search-console-api-original/v3
-
+https://developers.google.com/google-ads/api/reference/rpc/v9/GoogleAdsService#searchstream
 
 ---------------------------------------------------------------------------------------------
 

--- a/docs/google.rst
+++ b/docs/google.rst
@@ -10,3 +10,6 @@ https://developers.google.com/webmaster-tools/search-console-api-original/v3
 
 .. autoclass:: soomgogather.google.searchconsole.SearchConsole
     :members:
+
+.. autoclass:: soomgogather.google.googleads.GoogleAds
+    :members:

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import setuptools
 
 install_requires = [
     "marshmallow",
-    "google-api-core",
     "google-api-python-client",
+    "google-ads",
 ]
 
 tests_requires = [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ tests_requires = [
 
 def get_long_description() -> str:
     return (
-        open("README.md", encoding="utf8").read().strip() + "\n\n" + open("CHANGELOG.md", encoding="utf8").read().strip()
+        open("README.md", encoding="utf8").read().strip()
+        + "\n\n"
+        + open("CHANGELOG.md", encoding="utf8").read().strip()
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.6",
-    install_requires=[],
+    install_requires=install_requires,
     extras_require={"test": tests_requires},
     zip_safe=False,
     # test_suite=''

--- a/src/soomgogather/google/__init__.py
+++ b/src/soomgogather/google/__init__.py
@@ -1,1 +1,2 @@
 from .searchconsole import SearchConsole
+from .googleads import GoogleAds

--- a/src/soomgogather/google/__init__.py
+++ b/src/soomgogather/google/__init__.py
@@ -1,2 +1,2 @@
-from .searchconsole import SearchConsole
 from .googleads import GoogleAds
+from .searchconsole import SearchConsole

--- a/src/soomgogather/google/googleads.py
+++ b/src/soomgogather/google/googleads.py
@@ -53,13 +53,7 @@ class GoogleAds:
     """
 
     def __init__(self, credentials=None, version="v8"):
-        if credentials is None:
-            self.client = self._create_client_from_default(version)
-        elif 'key_file' in credentials:
-            self.client = self._create_client_from_file(credentials.get('key_file'), version)
-        else:
-            self.client = self._create_client_from_dict(credentials, version)
-
+        self.client = self._create_client(credentials, version)
         self.service = self.client.get_service("GoogleAdsService")
 
     class _GoogleAdsSchema(Schema):
@@ -75,24 +69,21 @@ class GoogleAds:
         if "summary_row_setting" in params:
             try:
                 params["summary_row_setting"] = params["summary_row_setting"].upper()
-            except ValidationError as err:
+            except AttributeError as err:
                 raise ValueError(f"summary_row_setting is a string type.: {err}")
         try:
             return self._GoogleAdsSchema().load(params)
         except ValidationError as err:
             raise ValueError(f"incorrect parameters: {err}")
 
-    def _create_client_from_file(self, key_file, version):
-        client = GoogleAdsClient.load_from_storage(path=key_file, version=version)
-        return client
-
-    def _create_client_from_dict(self, dict, version):
-        client = GoogleAdsClient.load_from_dict(dict, version=version)
-        return client
-
-    def _create_client_from_default(self, version):
-        client = GoogleAdsClient.load_from_storage(version=version)
-        return client
+    def _create_client(self, credentials, version):
+        if credentials is None:
+            _client = GoogleAdsClient.load_from_storage(version=version)
+        elif 'key_file' in credentials:
+            _client = GoogleAdsClient.load_from_storage(path=credentials.get('key_file'), version=version)
+        else:
+            _client = GoogleAdsClient.load_from_dict(credentials, version=version)
+        return _client
 
     def search_stream_request(self, params):
         """전달한 필터와 조건에 맞는 GoogleAds 정보를 받아온다.

--- a/src/soomgogather/google/googleads.py
+++ b/src/soomgogather/google/googleads.py
@@ -76,7 +76,7 @@ class GoogleAds:
             try:
                 params["summary_row_setting"] = params["summary_row_setting"].upper()
             except ValidationError as err:
-                raise ValueError(f"'summary_row_setting' is a string type.")
+                raise ValueError(f"summary_row_setting is a string type.: {err}")
         try:
             return self._GoogleAdsSchema().load(params)
         except ValidationError as err:

--- a/src/soomgogather/google/googleads.py
+++ b/src/soomgogather/google/googleads.py
@@ -85,6 +85,11 @@ class GoogleAds:
             _client = GoogleAdsClient.load_from_dict(credentials, version=version)
         return _client
 
+    def _get_summary(self, params):
+        return getattr(
+            self.client.get_type('SummaryRowSettingEnum').SummaryRowSetting, params['summary_row_setting']
+        ).value
+
     def search_stream_request(self, params):
         """전달한 필터와 조건에 맞는 GoogleAds 정보를 받아온다.
 
@@ -104,10 +109,7 @@ class GoogleAds:
         search_request.query = params.get('query')
 
         if "summary_row_setting" in params:
-            summary = getattr(
-                self.client.get_type('SummaryRowSettingEnum').SummaryRowSetting, params.get('summary_row_setting')
-            )
-            search_request.summary_row_setting = summary.value
+            search_request.summary_row_setting = self._get_summary(params=params)
 
         stream = self.service.search_stream(search_request)
 

--- a/src/soomgogather/google/googleads.py
+++ b/src/soomgogather/google/googleads.py
@@ -1,16 +1,15 @@
+from google.ads.googleads.client import GoogleAdsClient
 from marshmallow import Schema, ValidationError, fields, validate
 
-from google.ads.googleads.client import GoogleAdsClient
 
-
-class GoogleAds():
+class GoogleAds:
     """GoogleAds search_stream_request
 
     GoogleAds를 사용한다는 것은 GoogleAds의 API를 사용한다는 의미이기 때문에 Class 생성시 GoogleAds서비스까지 생성한다.
 
     query data 요청시 parameter는 다른 soomgo-gather와의 프로토콜을 동일하게 하기 위해 json 형식을 사용한다.
 
-    Google developer key를 인스턴스의 기본설정 값(GOOGLE_ADS_CONFIGURATION_FILE_PATH)이나 
+    Google developer key를 인스턴스의 기본설정 값(GOOGLE_ADS_CONFIGURATION_FILE_PATH)이나
     google developer 키파일(.yaml) 또는 dict를 사용하여 GoogleAds 서비스 객체를 생성한다.
 
     생성한 GoogleAds 인스턴스를 사용하여 쿼리를 통해 원하는 데이터에 대한 통계 정보를 얻을 수 있다.
@@ -53,8 +52,8 @@ class GoogleAds():
 
     def __init__(self, key_file=None, dict=None, version="v8"):
         if key_file is not None:
-            self.client = self. _create_client_from_file(key_file, version)
-        elif dict is  not None:
+            self.client = self._create_client_from_file(key_file, version)
+        elif dict is not None:
             self.client = self._create_client_from_dict(dict, version)
         else:
             self.client = self._create_client_from_default(version)
@@ -64,7 +63,9 @@ class GoogleAds():
         query = fields.Str(required=True)
         customer_id = fields.Str(required=True)
         summary_row_setting = fields.Str(
-            validate=validate.OneOf(['UNSPECIFIED','UNKNOWN','NO_SUMMARY_ROW','SUMMARY_ROW_WITH_RESULTS','SUMMARY_ROW_ONLY'])
+            validate=validate.OneOf(
+                ['UNSPECIFIED', 'UNKNOWN', 'NO_SUMMARY_ROW', 'SUMMARY_ROW_WITH_RESULTS', 'SUMMARY_ROW_ONLY']
+            )
         )
 
     def _get_params(self, params):
@@ -104,9 +105,11 @@ class GoogleAds():
         search_request = self.client.get_type("SearchGoogleAdsStreamRequest")
         search_request.customer_id = params.get('customer_id')
         search_request.query = params.get('query')
-
+        print(params)
         if "summary_row_setting" in params:
-            summary = getattr(self.client.get_type('SummaryRowSettingEnum').SummaryRowSetting,params.get('summary_row_setting'))
+            summary = getattr(
+                self.client.get_type('SummaryRowSettingEnum').SummaryRowSetting, params.get('summary_row_setting')
+            )
             search_request.summary_row_setting = summary.value
 
         stream = self.service.search_stream(search_request)

--- a/src/soomgogather/google/googleads.py
+++ b/src/soomgogather/google/googleads.py
@@ -49,7 +49,6 @@ class GoogleAds:
         ...     for row in batch.results:
         ...         matrics = row.matrics
         ...         print(matrics.clicks)
-
     """
 
     def __init__(self, credentials=None, version="v8"):
@@ -90,18 +89,21 @@ class GoogleAds:
             self.client.get_type('SummaryRowSettingEnum').SummaryRowSetting, params['summary_row_setting']
         ).value
 
-    def search_stream_request(self, params):
+    def search_stream_request(self, params={}):
         """전달한 필터와 조건에 맞는 GoogleAds 정보를 받아온다.
 
+        :param params: stream request를 위한 매개변수, query, customer_id는 필수
+        :type params: dict
+
         **params:**
-         - query: 데이터를 추출할 쿼리 (required)
-         - customer_id: GoogleAds customer ID (required)
-         - summary_row_setting: summary row에 대한 설정 (option)
-                UNSPECIFIED : 명시되지 않음.
-                UNKNOWN : 반환 요약 행의 unknown 값을 표시.
-                NO_SUMMARY_ROW : 요약 행을 반환하지 않음.
-                SUMMARY_ROW_WITH_RESULTS : 결과와 함께 요약 행을 반환. 요약 행은 마지막 배치에서만 반환(마지막 배치에는 결과가 포함되지 않음).
-                SUMMARY_ROW_ONLY : 요약 행만 반환하고 결과는 반환하지 않음.
+            - *query* (`str`) : 데이터를 추출할 쿼리
+            - *customer_id* (`str`) : GoogleAds customer ID
+            - *summary_row_setting* (`str, optional`) - summary row에 대한 설정
+                - UNSPECIFIED : 명시되지 않음.
+                - UNKNOWN : 반환 요약 행의 unknown 값을 표시.
+                - NO_SUMMARY_ROW : 요약 행을 반환하지 않음.
+                - SUMMARY_ROW_WITH_RESULTS : 결과와 함께 요약 행을 반환. 요약 행은 마지막 배치에서만 반환(마지막 배치에는 결과가 포함되지 않음).
+                - SUMMARY_ROW_ONLY : 요약 행만 반환하고 결과는 반환하지 않음.
         """
         params = self._get_params(params)
         search_request = self.client.get_type("SearchGoogleAdsStreamRequest")

--- a/src/soomgogather/google/googleads.py
+++ b/src/soomgogather/google/googleads.py
@@ -1,0 +1,114 @@
+from marshmallow import Schema, ValidationError, fields, validate
+
+from google.ads.googleads.client import GoogleAdsClient
+
+
+class GoogleAds():
+    """GoogleAds search_stream_request
+
+    GoogleAds를 사용한다는 것은 GoogleAds의 API를 사용한다는 의미이기 때문에 Class 생성시 GoogleAds서비스까지 생성한다.
+
+    query data 요청시 parameter는 다른 soomgo-gather와의 프로토콜을 동일하게 하기 위해 json 형식을 사용한다.
+
+    Google developer key를 인스턴스의 기본설정 값(GOOGLE_ADS_CONFIGURATION_FILE_PATH)이나 
+    google developer 키파일(.yaml) 또는 dict를 사용하여 GoogleAds 서비스 객체를 생성한다.
+
+    생성한 GoogleAds 인스턴스를 사용하여 쿼리를 통해 원하는 데이터에 대한 통계 정보를 얻을 수 있다.
+
+    https://developers.google.com/google-ads/api/reference/rpc/v9/SearchGoogleAdsStreamRequest
+
+    사용 예시) dict를 사용하여 GoogleAds 서비스 인스턴스를 생성한다.
+    키워드 퍼포먼스의 어제 데이터의 클릭수를 받아온다.
+
+    .. code-block:: python
+
+        >>> from soomgogather.google import GoogleAds
+
+        >>> customer_id = "123445678"
+        >>> query = "SELECT metrics.clicks FROM keyword_view WHERE segments.date DURING YESTERDAY"
+
+        >>> params = {
+        ...     'query': query,
+        ...     'customer_id': customer_id,
+        >>> }
+
+        >>> credentials_dict = {
+        ...     'developer_token': '<<PUT YOUR DEVELOPER TOKEN>>',
+        ...     'refresh_token': '<<PUT YOUR REFRESH TOKEN>>',
+        ...     'client_id': '<<PUT YOUR CLIENT ID>>',
+        ...     'client_secret': '<<PUT YOUR CLIENT SECRET>>',
+        ...     'use_proto_plus': True,
+        ...     'login_customer_id': '<<PUT YOUR LOGIN CUSTOMER ID>>',
+        >>> }
+
+        >>> service = GoogleAds(dict=credentials_dict)
+        >>> stream = service.search_stream_request(params)
+
+        >>> for batch in stream:
+        ...     for row in batch.results:
+        ...         matrics = row.matrics
+        ...         print(matrics.clicks)
+
+    """
+
+    def __init__(self, key_file=None, dict=None, version="v8"):
+        if key_file is not None:
+            self.client = self. _create_client_from_file(key_file, version)
+        elif dict is  not None:
+            self.client = self._create_client_from_dict(dict, version)
+        else:
+            self.client = self._create_client_from_default(version)
+        self.service = self.client.get_service("GoogleAdsService")
+
+    class _GoogleAdsSchema(Schema):
+        query = fields.Str(required=True)
+        customer_id = fields.Str(required=True)
+        summary_row_setting = fields.Str(
+            validate=validate.OneOf(['UNSPECIFIED','UNKNOWN','NO_SUMMARY_ROW','SUMMARY_ROW_WITH_RESULTS','SUMMARY_ROW_ONLY'])
+        )
+
+    def _get_params(self, params):
+        if "summary_row_setting" in params:
+            params["summary_row_setting"] = params["summary_row_setting"].upper()
+        try:
+            return self._GoogleAdsSchema().load(params)
+        except ValidationError as err:
+            raise ValueError(f"incorrect parameters: {err}")
+
+    def _create_client_from_file(self, key_file, version):
+        client = GoogleAdsClient.load_from_storage(path=key_file, version=version)
+        return client
+
+    def _create_client_from_dict(self, dict, version):
+        client = GoogleAdsClient.load_from_dict(dict, version=version)
+        return client
+
+    def _create_client_from_default(self, version):
+        client = GoogleAdsClient.load_from_storage(version=version)
+        return client
+
+    def search_stream_request(self, params):
+        """전달한 필터와 조건에 맞는 GoogleAds 정보를 받아온다.
+
+        **params:**
+         - query: 데이터를 추출할 쿼리 (required)
+         - customer_id: GoogleAds customer ID (required)
+         - summary_row_setting: summary row에 대한 설정
+                UNSPECIFIED : 명시되지 않음.
+                UNKNOWN : 반환 요약 행의 unknown 값을 표시.
+                NO_SUMMARY_ROW : 요약 행을 반환하지 않음.
+                SUMMARY_ROW_WITH_RESULTS : 결과와 함께 요약 행을 반환. 요약 행은 마지막 배치에서만 반환(마지막 배치에는 결과가 포함되지 않음).
+                SUMMARY_ROW_ONLY : 요약 행만 반환하고 결과는 반환하지 않음.
+        """
+        params = self._get_params(params)
+        search_request = self.client.get_type("SearchGoogleAdsStreamRequest")
+        search_request.customer_id = params.get('customer_id')
+        search_request.query = params.get('query')
+
+        if "summary_row_setting" in params:
+            summary = getattr(self.client.get_type('SummaryRowSettingEnum').SummaryRowSetting,params.get('summary_row_setting'))
+            search_request.summary_row_setting = summary.value
+
+        stream = self.service.search_stream(search_request)
+
+        return stream

--- a/src/soomgogather/google/searchconsole.py
+++ b/src/soomgogather/google/searchconsole.py
@@ -70,27 +70,30 @@ class SearchConsole(BaseGoogleClient):
     def query(self, site_url, params={}):
         """전달한 필터와 조건에 맞는 검색 트래픽에 대한 정보를 반환한다.
 
+        :param params: search console의 데이터를 받아오기 위한 매개변수, start_dt, end_dt는 필수
+        :type params: dict
+
         **params:**
-         - start_dt: 통계를 추출할 기간의 시작일, YYYY-MM-DD PT (UTC - 7:00/8:00) (required)
-         - end_dt: 통계를 추출할 기간의 종료일, YYYY-MM-DD PT (UTC - 7:00/8:00) (required)
-         - dimensions: 결과를 그룹핑할 키, 지정안하거나 여러개를 지정가능, 결과셋의 keys값
-            - country, device, date, page, query, searchAppearance
-         - row_limit: 반환되는 결과의 row수 지정
-            - default 1000, maximum = 25000
-         - start_row: 반환되는 결과의 시작 row 번호
-            - 결과셋은 0부터 시작하는 인덱스
-            - 양수만 가능
-         - type: 구글의 검색타입 필터
-            - web(default), video, image, news, discover, googleNews(구글 뉴스 앱)
-         - dimension_filter_groups: dimensions 로 그룹핑시 필터 및 조건
-            - groupType: 현재는 'and' 조건만 지원
-            - filters: dimension의 필터 설정 리스트
-                - 형식: (dimension name) (an operator) (a value)
-                - dimension: 필터를 지정할 dimension 이름 (country, device, date, query, searchAppearance)
-                - operator: contains, equals, notEquals, includingRegex, excludingRegex
-                - expression: 필터 값
-         - data_state: all(fresh data 포함) 또는 final 값으로 지정 (대소문자 구분안함)
-         - aggregation_type: 결과의 aggregation(집합) 타입, auto(default), byPage(by URI), byProperty(by property)
+            - *start_dt* (`str`) : 통계를 추출할 기간의 시작일, YYYY-MM-DD PT (UTC - 7:00/8:00) (required)
+            - *end_dt* (`str`) : 통계를 추출할 기간의 종료일, YYYY-MM-DD PT (UTC - 7:00/8:00) (required)
+            - *dimensions* (`list`) : 결과를 그룹핑할 키, 지정안하거나 여러개를 지정가능, 결과셋의 keys값
+                - country, device, date, page, query, searchAppearance
+            - *row_limit* (`int`) : 반환되는 결과의 row수 지정
+                - default 1000, maximum = 25000
+            - *start_row* (`int`) : 반환되는 결과의 시작 row 번호
+                - 결과셋은 0부터 시작하는 인덱스
+                - 양수만 가능
+            - *type* (`str`) : 구글의 검색타입 필터
+                - web(default), video, image, news, discover, googleNews(구글 뉴스 앱)
+            - *dimension_filter_groups* (`list`) : dimensions 로 그룹핑시 필터 및 조건
+                - groupType: 현재는 'and' 조건만 지원
+                - filters: dimension의 필터 설정 리스트
+                    - 형식: (dimension name) (an operator) (a value)
+                    - dimension: 필터를 지정할 dimension 이름 (country, device, date, query, searchAppearance)
+                    - operator: contains, equals, notEquals, includingRegex, excludingRegex
+                    - expression: 필터 값
+            - *data_state* (`str`) : all(fresh data 포함) 또는 final 값으로 지정 (대소문자 구분안함)
+            - *aggregation_type* (`str`) : 결과의 aggregation(집합)타입, auto(default), byPage(by URI), byProperty(by property)
         """
         response = self.service.searchanalytics().query(siteUrl=site_url, body=self._get_params(params)).execute()
         return response

--- a/src/soomgogather/naver/bizmoney.py
+++ b/src/soomgogather/naver/bizmoney.py
@@ -46,35 +46,47 @@ class Bizmoney(BaseSearchAD):
     def cost(self, params={}):
         """파라미터로 전달한 기간의 Bizmoney 사용된 금액을 반환한다.
 
+        :param params: 사용금액 데이터를 받아오기 위한 매개변수,  search_start_dt, search_end_dt 모두 필수
+        :type params: dict
+
         **params:**
-         - search_start_dt: 조회 시작일 (required)
-         - search_end_dt: 조회 종료일 (required)
+            - *search_start_dt* (`str`) : 조회 시작일, YYYYMMDD (KST)
+            - *search_end_dt* (`str`) : 조회 종료일, YYYYMMDD (KST)
         """
         return self.call('GET', '/billing/bizmoney/cost', params=self._get_params(params))
 
     def charge(self, params={}):
         """파라미터로 전달한 기간의 Bizmoney 충전 내역을 반환한다.
 
+        :param params: 충전 내역 데이터를 받아오기 위한 매개변수,  search_start_dt, search_end_dt 모두 필수
+        :type params: dict
+
         **params:**
-         - search_start_dt: 조회 시작일 (required)
-         - search_end_dt: 조회 종료일 (required)
+            - *search_start_dt* (`str`) : 조회 시작일, YYYYMMDD (KST)
+            - *search_end_dt* (`str`) : 조회 종료일, YYYYMMDD (KST)
         """
         return self.call('GET', '/billing/bizmoney/histories/charge', params=self._get_params(params))
 
     def exhaust(self, params={}):
         """파라미터로 전달한 기간의 Bizmoney 공제된 내역을 반환한다.
 
+        :param params: 공제 내역 데이터를 받아오기 위한 매개변수,  search_start_dt, search_end_dt 모두 필수
+        :type params: dict
+
         **params:**
-         - search_start_dt: 조회 시작일 (required)
-         - search_end_dt: 조회 종료일 (required)
+            - *search_start_dt* (`str`) : 조회 시작일, YYYYMMDD (KST)
+            - *search_end_dt* (`str`) : 조회 종료일, YYYYMMDD (KST)
         """
         return self.call('GET', '/billing/bizmoney/histories/exhaust', params=self._get_params(params))
 
     def period(self, params={}):
         """파라미터로 전달한 기간의 일자별 BizMoney 상태값을 반환한다.
 
+        :param params: 요청한 기간동안의 데이터를 받아오기 위한 매개변수,  search_start_dt, search_end_dt 모두 필수
+        :type params: dict
+
         **params:**
-         - search_start_dt: 조회 시작일 (required)
-         - search_end_dt: 조회 종료일 (required)
+            - *search_start_dt* (`str`) : 조회 시작일, YYYYMMDD (KST)
+            - *search_end_dt* (`str`) : 조회 종료일, YYYYMMDD (KST)
         """
         return self.call('GET', '/billing/bizmoney/histories/period', params=self._get_params(params))

--- a/src/soomgogather/naver/relkwdstat.py
+++ b/src/soomgogather/naver/relkwdstat.py
@@ -47,18 +47,19 @@ class RelKwdStat(BaseSearchAD):
     def list(self, params={}):
         """파라미터의 조건에 맞는 키워드의 지표를 반환한다.
 
-        **params:**
+        :param params: 연관 검색어 데이터를 받아오기 위한 매개변수, ``show_detail`` 을 제외한 5개의 파라미터 중 1개 이상 지정되어야 결과값이 나옴
+        :type params: dict
 
-        ``show_detail`` 을 제외한 5개의 파라미터 중 1개 이상 지정되어야 결과값이 나옴
-         - site_id: 채널타입이 SITE인 비즈니스 채널 ID(nccBusinessChannelId)
-         - biztp_id: 비즈니스 타입 ID
-         - hint_keywords: 검색어 - comma(,)로 구분하여 5개까지 가능, 공백 허용 안됨
+        **params:**
+            - *site_id* (`str`) : 채널타입이 SITE인 비즈니스 채널 ID(nccBusinessChannelId)
+            - *biztp_id* (`int`) :: 비즈니스 타입 ID
+            - *hint_keywords* (`str`) : 검색어 - comma(,)로 구분하여 5개까지 가능, 공백 허용 안됨
                 ex) ```soomgo, 숨고``` (X) ```soomgo,숨 고``` (X) ```soomgo,숨고``` (O)
-         - event: 시즌테마
-            - https://gist.github.com/naver-searchad/235202ffb08f9433b6f7cb10e45875f7#file-seasonal_event_code-md
-         - month: 월
-         - show_detail: 상세정보 조회 여부
-            - 0: 상세정보 조회안함(기본값)
-            - 1: 상세정보 조회
+            - *event* (`int`) : 시즌테마
+                - https://gist.github.com/naver-searchad/235202ffb08f9433b6f7cb10e45875f7#file-seasonal_event_code-md
+            - *month* (`int`) : 월
+            - *show_detail* (`int`) : 상세정보 조회 여부
+                - 0: 상세정보 조회안함(기본값)
+                - 1: 상세정보 조회
         """
         return self.call('GET', '/keywordstool', params=self._get_params(params))

--- a/tests/test_google_googleads.py
+++ b/tests/test_google_googleads.py
@@ -1,19 +1,23 @@
+import pandas as pd
+from google.ads.googleads.client import GoogleAdsClient
+from google.ads.googleads.v8.enums.types.summary_row_setting import SummaryRowSettingEnum
+from google.ads.googleads.v8.services.services.google_ads_service.client import GoogleAdsServiceClient
+from google.ads.googleads.v8.services.types.google_ads_service import SearchGoogleAdsStreamRequest
 
 from soomgogather.google import GoogleAds
-import pandas as pd
 
-customer_id = "123456"
+customer_id = "1231231"
 
 query = """
   SELECT
     campaign.id,
     ad_group.id,
-    ad_group_criterion.criterion_id, 
-    ad_group_criterion.age_range.type, 
-    ad_group_criterion.status, 
+    ad_group_criterion.criterion_id,
+    ad_group_criterion.age_range.type,
+    ad_group_criterion.status,
     ad_group.cpc_bid_micros,
     ad_group.cpm_bid_micros,
-    ad_group.cpv_bid_micros, 
+    ad_group.cpv_bid_micros,
     ad_group_criterion.final_urls,
     ad_group_criterion.final_url_suffix,
     metrics.average_cost
@@ -27,68 +31,95 @@ params = {
     'customer_id': customer_id,
 }
 
-def _create_client_from_file():
+
+def _create_client_from_file(mocker):
+    mocker.patch('google.ads.googleads.client.GoogleAdsClient.load_from_storage', return_value=GoogleAdsClient)
+    mocker.patch('google.ads.googleads.client.GoogleAdsClient.get_service', return_value=GoogleAdsServiceClient)
 
     service = GoogleAds(key_file='api_google_googleads.yaml')
 
     return service
 
-def _create_client_from_dict():
+
+def _create_client_from_dict(mocker):
+    mocker.patch('google.ads.googleads.client.GoogleAdsClient.load_from_dict', return_value=GoogleAdsClient)
+    mocker.patch('google.ads.googleads.client.GoogleAdsClient.get_service', return_value=GoogleAdsServiceClient)
 
     credentials_dict = {
-        'developer_token': 'developer_token',
-        'refresh_token': 'refresh_token',
-        'client_id': '434sdfx-123zdfserw.apps.googleusercontent.com',
-        'client_secret': 'GSDE4R-ADCSER',
+        'developer_token': 'AEARD234sd3w_Es2',
+        'refresh_token': 'SD32rssdf42-AsdF435sf-VSSD3sfxv',
+        'client_id': '134463443-4SFxfwdxx.apps.googleusercontent.com',
+        'client_secret': 'HESDFES8-SNsdfSEF',
         'use_proto_plus': True,
-        'login_customer_id': "5422345",
-        }
+        'login_customer_id': "2352373",
+    }
 
     service = GoogleAds(dict=credentials_dict)
 
     return service
 
-def _create_client_from_default():
+
+def _create_client_from_default(mocker):
+    mocker.patch('google.ads.googleads.client.GoogleAdsClient.load_from_storage', return_value=GoogleAdsClient)
+    mocker.patch('google.ads.googleads.client.GoogleAdsClient.get_service', return_value=GoogleAdsServiceClient)
 
     service = GoogleAds()
 
     return service
 
-def test_googleads_stream_file():
-    service = _create_client_from_file()
+
+def test_googleads_stream_file(mocker):
+    mocker.patch('google.ads.googleads.client.GoogleAdsClient.get_type', return_value=SearchGoogleAdsStreamRequest)
+    mocker.patch(
+        'google.ads.googleads.v8.services.services.google_ads_service.client.GoogleAdsServiceClient.search_stream',
+        return_value='success',
+    )
+    service = _create_client_from_file(mocker)
     stream = service.search_stream_request(params)
-    
-    for batch in stream:
-        for row in batch.results:
-            campaign = row.campaign
-            ad_group = row.ad_group
-            criterion = row.ad_group_criterion
-            print(
-                f'CampaignId" {campaign.id}"  '
-                f'AdGroupId" {ad_group.id}" '
-                f'CriterionId" {criterion.criterion_id}" '
-                f'Status" {criterion.status}" '
-                f'CpcBid" {ad_group.cpc_bid_micros}" '
-                f'CpmBid" {ad_group.cpm_bid_micros}" '
-                f'CpvBid" {ad_group.cpv_bid_micros}" '
-                f'FinalUrls" {criterion.final_urls}" '
-            )
+
     assert stream
 
-def test_googleads_stream_dict():
 
-    service = _create_client_from_dict()
-    stream = service.search_stream_request(params)
-    # _print_data(stream)
-    assert stream
+def test_googleads_stream_dict(mocker):
+    mocker.patch('google.ads.googleads.client.GoogleAdsClient.get_type', return_value=SearchGoogleAdsStreamRequest)
+    mocker.patch(
+        'google.ads.googleads.v8.services.services.google_ads_service.client.GoogleAdsServiceClient.search_stream',
+        return_value='success',
+    )
 
-def test_googleads_stream_default():
-    import os
-    os.environ["GOOGLE_ADS_CONFIGURATION_FILE_PATH"] = "/Users/rosa/Downloads/api_google_googleads (2).yaml"
+    params = {
+        'query': query,
+        'customer_id': customer_id,
+        'summary_row_setting': 'UNSPECIFIED',
+    }
 
-    service = _create_client_from_default()
+    service = _create_client_from_dict(mocker)
+
     try:
-        stream = service.search_stream_request(params)
+        service.search_stream_request(params)
+    except Exception as err:
+        assert type(err) == AttributeError
+
+
+def test_googleads_stream_default(mocker):
+    mocker.patch('google.ads.googleads.client.GoogleAdsClient.get_type', return_value=SearchGoogleAdsStreamRequest)
+    mocker.patch(
+        'google.ads.googleads.v8.services.services.google_ads_service.client.GoogleAdsServiceClient.search_stream',
+        return_value='success',
+    )
+
+    import os
+
+    os.environ["GOOGLE_ADS_CONFIGURATION_FILE_PATH"] = "api_google_googleads.yaml"
+
+    params = {
+        'query': query,
+        'customer_id': customer_id,
+        'summary_row_setting': 'UNSPECIFIED!',
+    }
+
+    service = _create_client_from_default(mocker)
+    try:
+        service.search_stream_request(params)
     except Exception as err:
         assert type(err) == ValueError
-

--- a/tests/test_google_googleads.py
+++ b/tests/test_google_googleads.py
@@ -35,7 +35,11 @@ def _create_client_from_file(mocker):
     mocker.patch('google.ads.googleads.client.GoogleAdsClient.load_from_storage', return_value=GoogleAdsClient)
     mocker.patch('google.ads.googleads.client.GoogleAdsClient.get_service', return_value=GoogleAdsServiceClient)
 
-    service = GoogleAds(key_file='api_google_googleads.yaml')
+    credentials_dict = {
+        'key_file': 'api_google_googleads.yaml'
+    }
+
+    service = GoogleAds(credentials=credentials_dict)
 
     return service
 
@@ -53,8 +57,7 @@ def _create_client_from_dict(mocker):
         'login_customer_id': "2352373",
     }
 
-    service = GoogleAds(dict=credentials_dict)
-
+    service = GoogleAds(credentials=credentials_dict)
     return service
 
 

--- a/tests/test_google_googleads.py
+++ b/tests/test_google_googleads.py
@@ -35,9 +35,7 @@ def _create_client_from_file(mocker):
     mocker.patch('google.ads.googleads.client.GoogleAdsClient.load_from_storage', return_value=GoogleAdsClient)
     mocker.patch('google.ads.googleads.client.GoogleAdsClient.get_service', return_value=GoogleAdsServiceClient)
 
-    credentials_dict = {
-        'key_file': 'api_google_googleads.yaml'
-    }
+    credentials_dict = {'key_file': 'api_google_googleads.yaml'}
 
     service = GoogleAds(credentials=credentials_dict)
 

--- a/tests/test_google_googleads.py
+++ b/tests/test_google_googleads.py
@@ -1,0 +1,94 @@
+
+from soomgogather.google import GoogleAds
+import pandas as pd
+
+customer_id = "123456"
+
+query = """
+  SELECT
+    campaign.id,
+    ad_group.id,
+    ad_group_criterion.criterion_id, 
+    ad_group_criterion.age_range.type, 
+    ad_group_criterion.status, 
+    ad_group.cpc_bid_micros,
+    ad_group.cpm_bid_micros,
+    ad_group.cpv_bid_micros, 
+    ad_group_criterion.final_urls,
+    ad_group_criterion.final_url_suffix,
+    metrics.average_cost
+  FROM keyword_view
+  WHERE ad_group_criterion.status in ('ENABLED', 'PAUSED') and segments.date DURING YESTERDAY
+  LIMIT 5
+"""
+
+params = {
+    'query': query,
+    'customer_id': customer_id,
+}
+
+def _create_client_from_file():
+
+    service = GoogleAds(key_file='api_google_googleads.yaml')
+
+    return service
+
+def _create_client_from_dict():
+
+    credentials_dict = {
+        'developer_token': 'developer_token',
+        'refresh_token': 'refresh_token',
+        'client_id': '434sdfx-123zdfserw.apps.googleusercontent.com',
+        'client_secret': 'GSDE4R-ADCSER',
+        'use_proto_plus': True,
+        'login_customer_id': "5422345",
+        }
+
+    service = GoogleAds(dict=credentials_dict)
+
+    return service
+
+def _create_client_from_default():
+
+    service = GoogleAds()
+
+    return service
+
+def test_googleads_stream_file():
+    service = _create_client_from_file()
+    stream = service.search_stream_request(params)
+    
+    for batch in stream:
+        for row in batch.results:
+            campaign = row.campaign
+            ad_group = row.ad_group
+            criterion = row.ad_group_criterion
+            print(
+                f'CampaignId" {campaign.id}"  '
+                f'AdGroupId" {ad_group.id}" '
+                f'CriterionId" {criterion.criterion_id}" '
+                f'Status" {criterion.status}" '
+                f'CpcBid" {ad_group.cpc_bid_micros}" '
+                f'CpmBid" {ad_group.cpm_bid_micros}" '
+                f'CpvBid" {ad_group.cpv_bid_micros}" '
+                f'FinalUrls" {criterion.final_urls}" '
+            )
+    assert stream
+
+def test_googleads_stream_dict():
+
+    service = _create_client_from_dict()
+    stream = service.search_stream_request(params)
+    # _print_data(stream)
+    assert stream
+
+def test_googleads_stream_default():
+    import os
+    os.environ["GOOGLE_ADS_CONFIGURATION_FILE_PATH"] = "/Users/rosa/Downloads/api_google_googleads (2).yaml"
+
+    service = _create_client_from_default()
+    try:
+        stream = service.search_stream_request(params)
+    except Exception as err:
+        assert type(err) == ValueError
+

--- a/tests/test_google_googleads.py
+++ b/tests/test_google_googleads.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.v8.enums.types.summary_row_setting import SummaryRowSettingEnum
 from google.ads.googleads.v8.services.services.google_ads_service.client import GoogleAdsServiceClient

--- a/tests/test_google_googleads.py
+++ b/tests/test_google_googleads.py
@@ -100,6 +100,19 @@ def test_googleads_stream_dict(mocker):
     except Exception as err:
         assert type(err) == AttributeError
 
+    params = {
+        'query': query,
+        'customer_id': customer_id,
+        'summary_row_setting': {'row_setting': 'SUMMARY_ROW_ONLY'},
+    }
+
+    service = _create_client_from_dict(mocker)
+
+    try:
+        service.search_stream_request(params)
+    except Exception as err:
+        assert type(err) == ValueError
+
 
 def test_googleads_stream_default(mocker):
     mocker.patch('google.ads.googleads.client.GoogleAdsClient.get_type', return_value=SearchGoogleAdsStreamRequest)


### PR DESCRIPTION
googleads 추가
- 공식 파이썬 패키지를 활용
- 다른 soomgo-gather의 파라미터와 프로토콜을 맞추기위해 json 형식으로 정의
- googleads 클라이언트 생성시 default, dict, yaml 파일 활요하는 세가지 방식 지원

테스트 코드 커버롤 100% 달성 안됨
- search_stream_request 에서 client.get_type 를 두 번 호출하는데 return value가 다름
- mock return_value를 차례대로 전달하는 방법을 못찾음

